### PR TITLE
Fehler mit "Vorwarnung" auf "Warnung" auf Halt behoben

### DIFF
--- a/res/scripts/nightfury/signals/type_n_builder.lua
+++ b/res/scripts/nightfury/signals/type_n_builder.lua
@@ -317,6 +317,7 @@ function builder.evaluateMainSignal(params)
 	
 	if nextStopSignalDistance == 1 then
 		canIndicateSpeed = false
+		displayWarning = false
 	elseif displayWarning and nextStopSignalDistance == 2 then
 		canIndicateSpeed = false
 		displayWarning = true

--- a/res/scripts/nightfury/signals/type_n_builder.lua
+++ b/res/scripts/nightfury/signals/type_n_builder.lua
@@ -445,4 +445,3 @@ function builder.buildGroundFaces(tunnelHelperOn)
 	return groundFaces, models
 end
 
-return builder


### PR DESCRIPTION
# Fehler mit Vorwarnung auf Warnung auf Halt
Aktuell verhält sich der Mod so, dass das letzte Signal vor einem Halt zeigenden Signal "Vorwarnung" zeigt, sobald dieses im Signal aktiviert ist. Dieses Verhalten verstösst gegen die FDL 300.2, das letzte Signal vor dem Halt muss Warnung oder Kurze Fahrt zeigen.
<img width="395" height="566" alt="image" src="https://github.com/user-attachments/assets/13e73920-6194-43cd-8597-5db3656541ec" />


Mit meiner Änderung wird der Parameter `displayWarning` auf `false` gesetzt, damit unter keinen Umständen eine Warnung angezeigt werden kann.
<img width="371" height="523" alt="image" src="https://github.com/user-attachments/assets/d80498b5-b32e-42cf-b813-38cb2bfba854" />

Nun weiss ich nicht, ob das der richtige Fix ist. Beim lokalen Testen hat es bisher gut ausgesehen.